### PR TITLE
Sanitize data from Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ template:
               {% set discovery_device = states('input_text.settings_ble_gateway_add_device') %}
               {% set ns.items = ns.items + [ discovery_device | replace(':', '') | trim ] if discovery_device | length == 17 and discovery_device is match('(?:[0-9A-Fa-f]{2}[:]){5}(?:[0-9A-Fa-f]{2})', ignorecase=False)  %}
             {% endif %}
-            {{ ns.items | unique | join('') | replace(':', '') }}
+            {{ ns.items | sort | unique | join('') | replace(':', '') }}
 ```
 
 **More configuration examples you can find in [examples](examples) folder.**

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ input_text:
     name: BLE Gateway Add Device
     icon: mdi:bluetooth-connect
     pattern: (?:[0-9A-Fa-f]{2}[:]){5}(?:[0-9A-Fa-f]{2})
+    min: 17
+    max: 17
 
 template:
   - binary_sensor:

--- a/README.md
+++ b/README.md
@@ -135,21 +135,24 @@ switch:
     turn_off_action: [lambda: id(blegateway).set_discovery(false);]
     disabled_by_default: true
     entity_category: config
-
+```
+```yaml
 # Home Assistant
 input_boolean:
   settings_ble_gateway:
     name: BLE Gateway
     icon: mdi:bluetooth
+    initial: on
   settings_ble_gateway_discovery:
     name: BLE Gateway Discovery
     icon: mdi:bluetooth-connect
-
+    initial: off
+    
 input_text:
   settings_ble_gateway_add_device:
     name: BLE Gateway Add Device
     icon: mdi:bluetooth-connect
-    initial: ''
+    pattern: (?:[0-9A-F]{2}[:]){5}(?:[0-9A-F]{2})
 
 template:
   - binary_sensor:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ input_text:
     name: BLE Gateway Add Device
     icon: mdi:bluetooth-connect
     pattern: (?:[0-9A-Fa-f]{2}[:]){5}(?:[0-9A-Fa-f]{2})
-    min: 17
+    min: 0
     max: 17
 
 template:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ switch:
     entity_category: config
 ```
 
-Add the following to your custom configuration in Home Assistant ( or preferably add the following to Helpers )
+Add the following to your custom configuration in Home Assistant.
 
 ```yaml
 # Home Assistant


### PR DESCRIPTION
These changes sanitize the data being exported from Home Assistant to the esp32.  There is still a need to sanitize the data on the esp32 side as well, but these changes will fix the import data issues.